### PR TITLE
Add protected $url variable

### DIFF
--- a/Translate/Client.php
+++ b/Translate/Client.php
@@ -29,6 +29,11 @@ class Client {
      * @var Client $client A Guzzle client instance
      */
     protected $client;
+    
+    /**
+     * @string string $url API translation url
+     */
+    protected $url = null;
 
     /**
      * Constructor


### PR DESCRIPTION
An scrutinizer analysis return
# "Client.php

Line 41: The property "url" does not exist. Did you maybe forget to declare it?"
