### PR TITLE
Remove unnecessary url encoded.

### DIFF
--- a/Translate/Method/Detector.php
+++ b/Translate/Method/Detector.php
@@ -44,7 +44,7 @@ class Detector extends Method implements MethodInterface {
     {
         $this->getClient()->setConfig(array(
             'key'    => $this->apiKey,
-            'query'  => urlencode($query)
+            'query'  => $query
         ));
 
         return $this->process();

--- a/Translate/Method/Translator.php
+++ b/Translate/Method/Translator.php
@@ -76,7 +76,7 @@ class Translator extends Method implements MethodInterface {
 
         $this->getClient()->setConfig(array(
             'key'    => $this->apiKey,
-            'query'  => urlencode($query),
+            'query'  => $query,
             'source' => $source,
             'target' => $target
         ));


### PR DESCRIPTION
Different results.

``` php
// Detect a string language
$detector = $this->get('eko.google_translate.detector');
$value = $detector->detect('Salut, ceci est mon texte à détecter!');
// Result: 'ro'.

// Translate a string
$translator = $this->get('eko.google_translate.translator');
$value = $translator->translate('Hi, this is my text to detect!', 'fr', 'en');
// Result: 'Salut% 2C + ce + est + mon + texte + pour + détecter% 21'.
```

url encoded on the guzzle side automatically, I think that it is caused by the fact that it becomes the double encoding.
#### Remove 'urlencode':

``` php
// Detect a string language
$detector = $this->get('eko.google_translate.detector');
$value = $detector->detect('Salut, ceci est mon texte à détecter!');
// Result: 'fr'.

// Translate a string
$translator = $this->get('eko.google_translate.translator');
$value = $translator->translate('Hi, this is my text to detect!', 'fr', 'en');
// Result: 'Salut, ceci est mon texte à détecter!'.
```
