### PR TITLE
fix guzzle version requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     "require": {
         "php": "^5.3|^7.0",
         "symfony/framework-bundle": "^2.0|^3.0",
-        "guzzlehttp/guzzle": "5.0.*@dev"
+        "guzzlehttp/guzzle": "~5.2"
     },
     "autoload": {
         "psr-4": { "Eko\\GoogleTranslateBundle\\": "" }

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     "require": {
         "php": "^5.3|^7.0",
         "symfony/framework-bundle": "^2.0|^3.0",
-        "guzzlehttp/guzzle": "~5.2"
+        "guzzlehttp/guzzle": "~5.0"
     },
     "autoload": {
         "psr-4": { "Eko\\GoogleTranslateBundle\\": "" }


### PR DESCRIPTION
makes more sense to have the guzzle version in this way - your version breaks forward compatibility