### PR TITLE
Add plain text option to translate method

### DIFF
--- a/Tests/Method/TranslatorTest.php
+++ b/Tests/Method/TranslatorTest.php
@@ -55,6 +55,24 @@ class TranslatorTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * Test plain text option of the simple translate method.
+     */
+    public function testPlainTextTranslate()
+    {
+        // Given
+        $this->responseMock->expects($this->any())->method('json')->will($this->returnValue(
+            ['data' => ['translations' => [['translatedText' => "J'ai"]]]]
+        ));
+
+        // When
+        $value = $this->translator->translate('I have', 'fr', 'en', true);
+
+        // Then
+        $this->assertEquals($value, "J'ai", 'Should return "J\'ai"');
+    }
+    
+    
+    /**
      * Test multiple translate method using an array.
      */
     public function testMultipleTranslate()

--- a/Translate/Method/Translator.php
+++ b/Translate/Method/Translator.php
@@ -111,6 +111,7 @@ class Translator extends Method implements MethodInterface
      * @param string $target    A target language
      * @param string $source    A source language
      * @param bool   $plainText The source (and response) are plain text
+     *
      * @return string
      */
     protected function handle($query, $target, $source = null, $plainText = false)

--- a/Translate/Method/Translator.php
+++ b/Translate/Method/Translator.php
@@ -74,21 +74,22 @@ class Translator extends Method implements MethodInterface
      * Translates given string in given target language from a source language via the Google Translate API.
      * If source language is not defined, it use detector method to detect string language.
      *
-     * @param string|array $query    A query string to translate
-     * @param string       $target   A target language
-     * @param string       $source   A source language
-     * @param bool         $economic Enable the economic mode? (only 1 request)
+     * @param string|array $query     A query string to translate
+     * @param string       $target    A target language
+     * @param string       $source    A source language
+     * @param bool         $economic  Enable the economic mode? (only 1 request)
+     * @param bool         $plainText The source (and response) are plain text
      *
      * @return array|string
      */
-    public function translate($query, $target, $source = null, $economic = false)
+    public function translate($query, $target, $source = null, $economic = false, $plainText = false)
     {
         if (!is_array($query)) {
-            return $this->handle($query, $target, $source);
+            return $this->handle($query, $target, $source, $plainText);
         }
 
         if ($economic) {
-            $results = $this->handle(implode(self::ECONOMIC_DELIMITER, $query), $target, $source);
+            $results = $this->handle(implode(self::ECONOMIC_DELIMITER, $query), $target, $source, $plainText);
             $results = explode(self::ECONOMIC_DELIMITER, $results);
 
             return array_map('trim', $results);
@@ -97,7 +98,7 @@ class Translator extends Method implements MethodInterface
         $results = [];
 
         foreach ($query as $item) {
-            $results[] = $this->handle($item, $target, $source);
+            $results[] = $this->handle($item, $target, $source, $plainText);
         }
 
         return $results;
@@ -106,13 +107,13 @@ class Translator extends Method implements MethodInterface
     /**
      * Handles a translation request.
      *
-     * @param string $query  A query string to translate
-     * @param string $target A target language
-     * @param string $source A source language
-     *
+     * @param string $query     A query string to translate
+     * @param string $target    A target language
+     * @param string $source    A source language
+     * @param bool   $plainText The source (and response) are plain text
      * @return string
      */
-    protected function handle($query, $target, $source = null)
+    protected function handle($query, $target, $source = null, $plainText = false)
     {
         if (null === $source) {
             $source = $this->getDetector()->detect($query);
@@ -152,6 +153,7 @@ class Translator extends Method implements MethodInterface
                 'q'      => $subQuery,
                 'source' => $source,
                 'target' => $target,
+                'format' => ($plainText ? 'text' : 'html'),
             ];
 
             $result .= $this->process($options);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | "master"
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes, but no new tests written

Currently, the translate method always treats the source and target text as HTML.  Although the Google API behaves this way by default, they provide a "format" option for cases in which a plain text translation is preferred.  This PR implements that option.  

Without this option, the method may return HTML escape sequences for some characters.  For example, the apostrophe in "je n'ai pas".  If we're saving the translation result in a database, we want to save "je n'ai pas" not "je nl&#39;pas".  There may be other cases in which this option is useful.